### PR TITLE
1-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.1.0] 2020-09-27
 
 ### Added

--- a/src/currentUrlIs.php
+++ b/src/currentUrlIs.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use InvalidArgumentException;
 
-if (!function_exists("currentUrlIs")) {
+if (!function_exists("Folded\currentUrlIs")) {
     /**
      * Returns true if the current URL matches the given URL.
      * You don't have to pass the domain.

--- a/src/getCurrentUrl.php
+++ b/src/getCurrentUrl.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getCurrentUrl")) {
+if (!function_exists("Folded\getCurrentUrl")) {
     /**
      * Get the current URL, including the server protocol and the domain.
      *

--- a/src/getQueryString.php
+++ b/src/getQueryString.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use InvalidArgumentException;
 
-if (!function_exists("getQueryString")) {
+if (!function_exists("Folded\getQueryString")) {
     /**
      * Get the query string value by its name.
      *

--- a/src/getQueryStrings.php
+++ b/src/getQueryStrings.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getQueryStrings")) {
+if (!function_exists("Folded\getQueryStrings")) {
     /**
      * Get all the query strings as an associative array.
      *

--- a/src/hasQueryString.php
+++ b/src/hasQueryString.php
@@ -6,7 +6,7 @@ namespace Folded;
 
 use InvalidArgumentException;
 
-if (!function_exists("hasQueryString")) {
+if (!function_exists("Folded\hasQueryString")) {
     /**
      * Returns true if the query string is present in the current URL, else returns false.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Added missing namespace `Folded` from `function_exists` statements.

## Breaking

None.